### PR TITLE
Set custom logo as favicon

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@
 import type {Metadata} from 'next';
 import { GeistSans } from 'geist/font/sans';
 import { GeistMono } from 'geist/font/mono';
+import akLogo from '@/components/icons/ak.jpg';
 import './globals.css';
 import { AuthProvider } from '@/contexts/AuthContext';
 import { AppHeader } from '@/components/layout/AppHeader';
@@ -11,6 +12,9 @@ import { cn } from '@/lib/utils';
 export const metadata: Metadata = {
   title: 'Arena Klein Beach Tennis',
   description: 'Reserve sua quadra de beach tennis na Arena Klein.',
+  icons: {
+    icon: akLogo.src,
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- remove duplicate public image
- use `src/components/icons/ak.jpg` as the favicon

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: multiple TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_686e957be71083319d824583c186b465