### PR TITLE
Fix login field validation clearing

### DIFF
--- a/src/components/auth/ForgotPasswordForm.tsx
+++ b/src/components/auth/ForgotPasswordForm.tsx
@@ -143,9 +143,10 @@ export function ForgotPasswordForm() {
               id="email"
               type="email"
               placeholder="seu.email@exemplo.com"
-              {...form.register("email")}
-              disabled={isLoading || isTimerActive} 
-              onChange={handleEmailInputChange}
+              {...form.register("email", {
+                onChange: handleEmailInputChange,
+              })}
+              disabled={isLoading || isTimerActive}
             />
             {form.formState.errors.email && (
               <p className="text-sm text-destructive">{form.formState.errors.email.message}</p>

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -46,8 +46,7 @@ export function LoginForm() {
   }, [authError, clearAuthError]);
 
   const onSubmit = async (data: LoginFormValues) => {
-    console.log('LoginForm onSubmit triggered. Password length:', data.password.length, 'Data:', JSON.stringify(data));
-    clearAuthError(); 
+    clearAuthError();
     await login(data.email, data.password);
   };
 
@@ -77,11 +76,12 @@ export function LoginForm() {
               id="email"
               type="email"
               placeholder="seu.email@exemplo.com"
-              {...form.register("email")}
+              {...form.register("email", {
+                onChange: () => {
+                  if (authError) clearAuthError();
+                },
+              })}
               disabled={isLoading}
-              onChange={() => {
-                if (authError) clearAuthError();
-              }}
             />
             {form.formState.errors.email && (
               <p className="text-sm text-destructive">{form.formState.errors.email.message}</p>
@@ -100,11 +100,12 @@ export function LoginForm() {
               id="password"
               type="password"
               placeholder="Sua Senha"
-              {...form.register("password")}
+              {...form.register("password", {
+                onChange: () => {
+                  if (authError) clearAuthError();
+                },
+              })}
               disabled={isLoading}
-              onChange={() => {
-                if (authError) clearAuthError();
-              }}
             />
             {/* A mensagem de erro "A senha deve ter pelo menos 6 caracteres." vem da validação Zod (cliente) */}
             {form.formState.errors.password && (

--- a/src/components/auth/RegisterForm.tsx
+++ b/src/components/auth/RegisterForm.tsx
@@ -77,9 +77,10 @@ export function RegisterForm() {
               id="name"
               type="text"
               placeholder="Seu Nome Completo"
-              {...form.register("name")}
+              {...form.register("name", {
+                onChange: () => authError && clearAuthError(),
+              })}
               disabled={isLoading}
-              onChange={() => authError && clearAuthError()}
             />
             {form.formState.errors.name && (
               <p className="text-sm text-destructive">{form.formState.errors.name.message}</p>
@@ -91,9 +92,10 @@ export function RegisterForm() {
               id="email"
               type="email"
               placeholder="seu.email@exemplo.com"
-              {...form.register("email")}
+              {...form.register("email", {
+                onChange: () => authError && clearAuthError(),
+              })}
               disabled={isLoading}
-              onChange={() => authError && clearAuthError()}
             />
             {form.formState.errors.email && (
               <p className="text-sm text-destructive">{form.formState.errors.email.message}</p>
@@ -105,9 +107,10 @@ export function RegisterForm() {
               id="password"
               type="password"
               placeholder="Crie uma Senha"
-              {...form.register("password")}
+              {...form.register("password", {
+                onChange: () => authError && clearAuthError(),
+              })}
               disabled={isLoading}
-              onChange={() => authError && clearAuthError()}
             />
             {form.formState.errors.password && (
               <p className="text-sm text-destructive">{form.formState.errors.password.message}</p>
@@ -119,9 +122,10 @@ export function RegisterForm() {
               id="confirmPassword"
               type="password"
               placeholder="Confirme Sua Senha"
-              {...form.register("confirmPassword")}
+              {...form.register("confirmPassword", {
+                onChange: () => authError && clearAuthError(),
+              })}
               disabled={isLoading}
-              onChange={() => authError && clearAuthError()}
             />
             {form.formState.errors.confirmPassword && (
               <p className="text-sm text-destructive">{form.formState.errors.confirmPassword.message}</p>


### PR DESCRIPTION
## Summary
- preserve React Hook Form handlers while clearing auth errors in login, register, and forgot password forms

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Requires interactive setup)*
- `npm run typecheck` *(fails: TS7006 Parameter 'b' implicitly has an 'any' type ...)*

------
https://chatgpt.com/codex/tasks/task_e_68bc939474f0833189c0a70f9a1ab505