### PR TITLE
feat: export play slot type

### DIFF
--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -1,6 +1,8 @@
 
 import type { Court, PlaySlotConfig } from '@/lib/types';
 
+export type { PlaySlotConfig };
+
 export const APP_NAME = "Arena Klein Beach Tennis";
 
 // adminUserUids array foi removido. A verificação de admin agora é feita via coleção 'admins' no Firestore.


### PR DESCRIPTION
## Summary
- export `PlaySlotConfig` type from appConfig so pages can import it

## Testing
- `npm run typecheck` *(fails: Parameter 'b' implicitly has an 'any' type ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c09d90ff4c83319fd1430da186dea6