### PR TITLE
fix: handle missing onBehalfOf when updating bookings

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -28,6 +28,7 @@ import {
   getDocs,
   getDoc,
   updateDoc,
+  deleteField,
   Timestamp,
 } from 'firebase/firestore';
 import { useToast } from "@/hooks/use-toast";
@@ -467,8 +468,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
         time: newTime,
       };
 
-      if (newOnBehalfOfName !== undefined) { // If newOnBehalfOfName was passed
-        dataToUpdate.onBehalfOf = newOnBehalfOfName.trim() || undefined; // Set to undefined if empty string, to remove field
+      if (newOnBehalfOfName !== undefined) {
+        const trimmed = newOnBehalfOfName.trim();
+        dataToUpdate.onBehalfOf = trimmed ? trimmed : deleteField();
       }
 
 


### PR DESCRIPTION
## Summary
- ensure admin booking updates remove the onBehalfOf field instead of sending undefined

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive configuration)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c0aaa0928c8331bb3837679bf8d995