### PR TITLE
Select current date on courts calendar

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,6 +18,10 @@ export default function HomePage() {
 
   useEffect(() => {
     setIsClient(true);
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    setGloballySelectedDate(today);
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- set the home page courts calendar to default to today's date on initial load so users immediately see current availability

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68c9c11069688331bc396ec558034303